### PR TITLE
Refactor preload to handle more cases

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -2,41 +2,35 @@ import Ember from 'ember';
 
 const { RSVP } = Ember;
 
+function getPromise(object, property) {
+  return RSVP.resolve(Ember.get(object, property));
+}
+
 function preloadRecord(record, toPreload) {
-  return preloadAll([record], toPreload).then(() => {
-    return record;
-  });
+  if (!record) {
+    return RSVP.resolve(record);
+  }
+
+  switch(Ember.typeOf(toPreload)) {
+    case 'string':
+      return getPromise(record, toPreload).then(() => record);
+    case 'array':
+      return RSVP.all(toPreload.map((p) => preloadRecord(record, p))).then(() => record);
+    case 'object':
+      return RSVP.all(Object.keys(toPreload).map((p) =>
+        getPromise(record, p).then((data) => preload(data, toPreload[p])))).then(() => record);
+    default: throw 'Illegal Argument';
+  }
 }
 
 function preloadAll(records, toPreload) {
-    switch(Ember.typeOf(toPreload)) {
-      case 'object':
-        const properties = Object.keys(toPreload);
-        return RSVP.all(properties.map((p) => {
-          return RSVP.all(records.map((record) => {
-            return record.get(p);
-          })).then((data) => {
-            const subRecords = data.reduce((prev, cur) => prev.concat(cur.toArray()), []);
-            return preloadAll(subRecords, toPreload[p]);
-          });
-        })).then(() => records);
-      case 'string':
-        return RSVP.all(records.map((record) => record.get(toPreload)))
-          .then(() => records);
-      default: throw 'Illegal Argument';
-    }
+  return RSVP.all(records.map((record) => preload(record, toPreload)));
 }
 
 function preload(thing, toPreload) {
-  if (thing.then) {
-    return thing.then(() => {
-      return Ember.isArray(thing) ? preloadAll(thing, toPreload) : preloadRecord(thing, toPreload);
-    });
-  }
-  else {
+  return RSVP.resolve(thing).then(() => {
     return Ember.isArray(thing) ? preloadAll(thing, toPreload) : preloadRecord(thing, toPreload);
-  }
-
+  });
 }
 
 export default preload;

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -22,7 +22,7 @@ test('visiting /', function(assert) {
 
   server.get('/countries', function() {
     assert.ok(true, 'Countries requested');
-    return json({countries: [{id: 1, name: 'USA', cities: [1, 2]}]});
+    return json({countries: [{id: 1, name: 'USA', cities: [1, 2], capital: 1}]});
   });
 
   server.get('/cities', function() {
@@ -36,18 +36,27 @@ test('visiting /', function(assert) {
   server.get('/neighborhoods', function() {
     assert.ok(true, 'Neighborhoods requested');
     return json({neighborhoods: [
-      {city: 1, id: 1, name: 'Adams Morgan', streets: [1, 2]},
-      {city: 2, id: 2, name: 'Tenderloin', streets: [3]},
-      {city: 2, id: 3, name: 'Financial District ', streets: []}
+      {city: 1, id: 1, name: 'Adams Morgan', streets: [1, 2], parks: [1, 2]},
+      {city: 2, id: 2, name: 'Tenderloin', streets: [3], parks: []},
+      {city: 2, id: 3, name: 'Financial District', streets: [], parks: [3]}
+    ]});
+  });
+
+  server.get('/parks', function() {
+    assert.ok(true, 'Parks requested');
+    return json({parks: [
+      {neighborhood: 1, id: 1, name: 'Smithsonian National Zoological Park'},
+      {neighborhood: 1, id: 2, name: 'Meridian Hill Park'},
+      {neighborhood: 2, id: 3, name: 'Sue Bierman Park'},
     ]});
   });
 
   server.get('/streets', function() {
     assert.ok(true, 'Streets requested');
     return json({streets: [
-      {city: 1, id: 1, name: 'Adams Morgan', houses: [1, 2]},
-      {city: 2, id: 2, name: 'Tenderloin', houses: []},
-      {city: 2, id: 3, name: 'Financial District ', houses: []}
+      {neighborhood: 1, id: 1, name: 'California St.', houses: [1, 2]},
+      {neighborhood: 2, id: 2, name: 'Eddie St.', houses: []},
+      {neighborhood: 2, id: 3, name: 'Sacramento St.', houses: []}
     ]});
   });
 

--- a/tests/dummy/app/models/city.js
+++ b/tests/dummy/app/models/city.js
@@ -4,6 +4,7 @@ const { attr, hasMany, belongsTo }  = DS;
 
 export default DS.Model.extend({
   name: attr('string'),
-  country: belongsTo('country'),
+  country: belongsTo('country', {inverse: 'cities'}),
+  capitalOf: belongsTo('country', {inverse: 'capital'}),
   neighborhoods: hasMany('neighborhood')
 });

--- a/tests/dummy/app/models/country.js
+++ b/tests/dummy/app/models/country.js
@@ -1,8 +1,9 @@
 import DS from 'ember-data';
 
-const { attr, hasMany }  = DS;
+const { attr, belongsTo, hasMany }  = DS;
 
 export default DS.Model.extend({
   name: attr('string'),
-  cities: hasMany('city')
+  capital: belongsTo('city', {inverse: 'capitalOf'}),
+  cities: hasMany('city', {inverse: 'country'})
 });

--- a/tests/dummy/app/models/park.js
+++ b/tests/dummy/app/models/park.js
@@ -1,0 +1,8 @@
+import DS from 'ember-data';
+
+const { attr, belongsTo }  = DS;
+
+export default DS.Model.extend({
+  name: attr('string'),
+  neighborhood: belongsTo('neighborhood')
+});

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -3,6 +3,16 @@ import preload from 'ember-data-preload';
 
 export default Ember.Route.extend({
   model() {
-    return preload(this.store.findAll('country'), {cities: {neighborhoods: {streets: 'houses'}}});
+    return preload(this.store.findAll('country'), [
+      {
+        cities: {
+          neighborhoods: [
+            {streets: 'houses'},
+            'parks'
+          ]
+        }
+      },
+      'capital'
+    ]);
   }
 });


### PR DESCRIPTION
Hello,

I've modified the preload module to accept more use cases. I was having some problem with null properties and some combinations of pre-loading objects and arrays. Please let me know what you think.

The cases supported now are:
* `preload(thing, <string>)`
* `preload(thing, [ <string | object>, ... ])`
* `preload(thing, { property: <string | array | object>, ... })`

Previously some of these combinations where not supported.

Cheers! 